### PR TITLE
fix openshift-scc overlay ref

### DIFF
--- a/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
+++ b/openshift/kfdef/kfctl_openshift_v1.5.0_odh.yaml
@@ -8,7 +8,7 @@ spec:
   - kustomizeConfig:
       repoRef:
         name: manifests
-        path: openshift/openshiftstack/application/openshift/openshift-scc
+        path: openshift/openshiftstack/application/openshift/openshift-scc/overlays/istio
     name: openshift-scc
   - kustomizeConfig:
       repoRef:


### PR DESCRIPTION
**Which issue is resolved by this Pull Request:**
Resolves 

**Description of your changes:**
Update kfdef example to point to the correct overlay

**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 3.2.1**
    1. `make generate-changed-only`
    2. `make test`
